### PR TITLE
ci: enable Markdown no-duplicate-heading lint for siblings only

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,3 @@
+# no-duplicate-heading
+MD024:
+  siblings_only: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Markdown linting rule to prevent duplicate headings within the same section, enhancing document clarity and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->