### PR TITLE
ci: Markdown lint tweak

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -6,3 +6,6 @@ MD013:
   line_length: 120
   heading_line_length: 120
   code_block_line_length: 120
+# no-inline-html
+MD033:
+  allowed_elements: [ "table", "tr", "th", "td", "img", "div", "span" ]

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,3 +1,8 @@
 # no-duplicate-heading
 MD024:
   siblings_only: true
+# line-length
+MD013:
+  line_length: 120
+  heading_line_length: 120
+  code_block_line_length: 120


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new Markdown linting rules to enhance documentation quality.
		- Set maximum line length to 120 characters.
		- Allowed specific inline HTML elements in Markdown files.
- **Bug Fixes**
	- Retained existing rule for duplicate headings to ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->