### PR TITLE
ci: disable the `abstract` error code in mypy lint check

### DIFF
--- a/.github/linters/.mypy.ini
+++ b/.github/linters/.mypy.ini
@@ -2,3 +2,5 @@
 namespace_packages = True
 explicit_package_bases = True
 ignore_missing_imports = True
+# Because of https://github.com/python/mypy/issues/3115.
+disable_error_code = abstract


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration for MyPy to disable error reporting for abstract classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->