### PR TITLE
docs: Dem., rep. party platforms dataset citation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,10 +19,10 @@
   from <https://huggingface.co/datasets/mlburnham/polistance_issue_tweets>
 - Burnham, M. (2024). Dem., rep. party platform topics. Retrieved
   from <https://huggingface.co/datasets/mlburnham/dem_rep_party_platform_topics>
-    - Wolbrecht, Christina, Brooke Shannon, E.J. Fagan, Jones, Bryan D., Frank R. Baumgartner, Sean M. Theriault, Derek
-      A. Epp, Cheyenne Lee, Miranda E. Sullivan. 2023. Policy Agendas Project: Democratic Party Platform.
-    - Wolbrecht, Christina, Brooke Shannon, E.J. Fagan, Jones, Bryan D., Frank R. Baumgartner, Sean M. Theriault, Derek
-      A. Epp, Cheyenne Lee, Miranda E. Sullivan. 2023. Policy Agendas Project: Republican Party Platform.
+  - Wolbrecht, Christina, Brooke Shannon, E.J. Fagan, Jones, Bryan D., Frank R. Baumgartner, Sean M. Theriault, Derek
+  A. Epp, Cheyenne Lee, Miranda E. Sullivan. 2023. Policy Agendas Project: Democratic Party Platform.
+  - Wolbrecht, Christina, Brooke Shannon, E.J. Fagan, Jones, Bryan D., Frank R. Baumgartner, Sean M. Theriault, Derek
+    A. Epp, Cheyenne Lee, Miranda E. Sullivan. 2023. Policy Agendas Project: Republican Party Platform.
 - Nayak, J. (2024). Political ideologies. Retrieved
   from <https://huggingface.co/datasets/JyotiNayak/political_ideologies>. Licensed under Apache 2.0.
 - Çöltekin, Ç., Kopp, M., Morkevičius, V., Ljubešić, N., Meden, K., & Erjavec, T. (2024). Training data for the shared

--- a/readme.md
+++ b/readme.md
@@ -19,10 +19,10 @@
   from <https://huggingface.co/datasets/mlburnham/polistance_issue_tweets>
 - Burnham, M. (2024). Dem., rep. party platform topics. Retrieved
   from <https://huggingface.co/datasets/mlburnham/dem_rep_party_platform_topics>
-  - Wolbrecht, Christina, Brooke Shannon, E.J. Fagan, Jones, Bryan D., Frank R. Baumgartner, Sean M. Theriault, Derek
-  A. Epp, Cheyenne Lee, Miranda E. Sullivan. 2023. Policy Agendas Project: Democratic Party Platform.
-  - Wolbrecht, Christina, Brooke Shannon, E.J. Fagan, Jones, Bryan D., Frank R. Baumgartner, Sean M. Theriault, Derek
-    A. Epp, Cheyenne Lee, Miranda E. Sullivan. 2023. Policy Agendas Project: Republican Party Platform.
+  - Wolbrecht, Christina, Brooke Shannon, E.J. Fagan, Jones, Bryan D., Frank R. Baumgartner, Sean M. Theriault, Derek A.
+    Epp, Cheyenne Lee, Miranda E. Sullivan. 2023. Policy Agendas Project: Democratic Party Platform.
+  - Wolbrecht, Christina, Brooke Shannon, E.J. Fagan, Jones, Bryan D., Frank R. Baumgartner, Sean M. Theriault, Derek A.
+    Epp, Cheyenne Lee, Miranda E. Sullivan. 2023. Policy Agendas Project: Republican Party Platform.
 - Nayak, J. (2024). Political ideologies. Retrieved
   from <https://huggingface.co/datasets/JyotiNayak/political_ideologies>. Licensed under Apache 2.0.
 - Çöltekin, Ç., Kopp, M., Morkevičius, V., Ljubešić, N., Meden, K., & Erjavec, T. (2024). Training data for the shared

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,10 @@
   from <https://huggingface.co/datasets/mlburnham/polistance_issue_tweets>
 - Burnham, M. (2024). Dem., rep. party platform topics. Retrieved
   from <https://huggingface.co/datasets/mlburnham/dem_rep_party_platform_topics>
+    - Wolbrecht, Christina, Brooke Shannon, E.J. Fagan, Jones, Bryan D., Frank R. Baumgartner, Sean M. Theriault, Derek
+      A. Epp, Cheyenne Lee, Miranda E. Sullivan. 2023. Policy Agendas Project: Democratic Party Platform.
+    - Wolbrecht, Christina, Brooke Shannon, E.J. Fagan, Jones, Bryan D., Frank R. Baumgartner, Sean M. Theriault, Derek
+      A. Epp, Cheyenne Lee, Miranda E. Sullivan. 2023. Policy Agendas Project: Republican Party Platform.
 - Nayak, J. (2024). Political ideologies. Retrieved
   from <https://huggingface.co/datasets/JyotiNayak/political_ideologies>. Licensed under Apache 2.0.
 - Çöltekin, Ç., Kopp, M., Morkevičius, V., Ljubešić, N., Meden, K., & Erjavec, T. (2024). Training data for the shared


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added references to two new datasets: 
		- Policy Agendas Project: Democratic Party Platform (2023)
		- Policy Agendas Project: Republican Party Platform (2023)

- **Documentation**
	- Updated the "Used datasets" section in the readme.md file to include the new dataset references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->