### PR TITLE
docs: remove a redundant table cell in the leave-one-out dataset benchmark docs

### DIFF
--- a/analysis/dataset_benchmark/leave_one_out/readme.md
+++ b/analysis/dataset_benchmark/leave_one_out/readme.md
@@ -166,7 +166,6 @@ model has not been fine-tuned on), while the heading of the column is the datase
     <td>585 / 1000 (58 %)</td>
     <td>580 / 1000 (58 %)</td>
     <td>345 / 1000 (34 %)</td>
-    <td>4550 / 7612 (60 %)</td>
 </tr>
 <tr>
     <th>CommonCrawl news articles</th>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new evaluation tables for model performance in the leave-one-out dataset benchmark.
	- Introduced a "POLITICS" section focusing on political bias predictions.
	- Updated accuracy data for the RoBERTa base model.
	- Included performance metrics for BERT base and RoBERTa base models across various datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->