### PR TITLE
ci: disable the Pylint cell-var-from-loop message

### DIFF
--- a/.github/linters/.python-lint
+++ b/.github/linters/.python-lint
@@ -15,3 +15,4 @@ disable=
     too-few-public-methods,
     no-name-in-module,
     wrong-import-order,
+    cell-var-from-loop,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Pylint configuration to disable warnings for cell variables referenced from loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->