### PR TITLE
style: set the project style Markdown indent size to 2

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -4,6 +4,11 @@
       <option name="OPTIMIZE_IMPORTS_SORT_NAMES_IN_FROM_IMPORTS" value="true" />
       <option name="OPTIMIZE_IMPORTS_JOIN_FROM_IMPORTS_WITH_SAME_SOURCE" value="true" />
     </Python>
+    <codeStyleSettings language="Markdown">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
     <codeStyleSettings language="Python">
       <option name="RIGHT_MARGIN" value="100" />
     </codeStyleSettings>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new code style settings for Markdown files, including an indentation size of 2.
  
- **Bug Fixes**
	- Retained existing Python code style settings without changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->