### PR TITLE
chore: set up JetBrains IDEs to use the local Black binary

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="Black">
+    <option name="enabledOnReformat" value="true" />
+    <option name="enabledOnSave" value="true" />
+    <option name="executionMode" value="BINARY" />
+    <option name="pathToExecutable" value="/usr/bin/black" />
     <option name="sdkName" value="Python 3.12 (political-leaning-prediction)" />
   </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="Remote Python 3.12.8 Docker Compose (notebook)" project-jdk-type="Python SDK" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated IDE configuration to enable automatic code formatting with Black
	- Configured Black formatter to run on code reformat and save events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->