### PR TITLE
docs: leave-one-out dataset benchmark intersection information

### DIFF
--- a/political_leaning/analysis/dataset_benchmark/leave_one_out/readme.md
+++ b/political_leaning/analysis/dataset_benchmark/leave_one_out/readme.md
@@ -1,6 +1,6 @@
 # Leave-one-out dataset benchmark
 
-If two datasets intersect with each other (as measured [here](../../dataset_intersection)) by more than 10 %, the
+If two datasets intersect with each other (as measured [here](../../dataset_intersection)) by more than 15 %, the
 smaller dataset is not a part of this benchmark to avoid spillover.
 
 From each dataset, a sample of 1 000 articles (or less if the dataset is smaller) has been taken while ensuring an equal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated dataset benchmark readme with a refined threshold for dataset intersection from 10% to 15%
  - Methodology for sampling articles and model evaluation remains consistent

<!-- end of auto-generated comment: release notes by coderabbit.ai -->