### PR TITLE
ci: disable the CSS linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: false
           FIX_YAML_PRETTIER: true
+          VALIDATE_CSS: false
+          VALIDATE_CSS_PRETTIER: false
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_RUST_2015: false
           VALIDATE_RUST_2018: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated lint workflow to disable CSS and CSS Prettier validation in automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->